### PR TITLE
Removed period from getting filtered by regex

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -54,7 +54,7 @@ const EVENTS_PER_BATCH = 10
 const REDIS_OFFSET_KEY = 'import_offset'
 
 const sanitizeSqlIdentifier = (unquotedIdentifier: string): string => {
-    return unquotedIdentifier.replace(/[^\w\d_]+/g, '')
+    return unquotedIdentifier.replace(/[^\w\d_.]+/g, '')
 }
 
 export const jobs: RedshiftImportPlugin['jobs'] = {


### PR DESCRIPTION
In redshift database we use schemas a lot and the regex was removing the period from table name so if we have a table xyz in schema abc and insert table name as abc.xyz it will process it as abcxyz and the plugin will not load properly.

