### PR TITLE
fix: safer redis cache with logging

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -105,11 +105,12 @@ export const setupPlugin: RedshiftImportPlugin['setupPlugin'] = async ({ config,
     // needed to prevent race conditions around offsets leading to events ingested twice
     let initialOffset = Number(offset)
     global.initialOffset = initialOffset
+    let newOffset = initialOffset
     try {
-        const newOffset = Math.floor(initialOffset / EVENTS_PER_BATCH)
+        newOffset = Math.floor(initialOffset / EVENTS_PER_BATCH)
         await cache.set(REDIS_OFFSET_KEY, newOffset)
     } catch(e) {
-        console.error('could not cache redis offset as: ', initialOffset, ' calculated using ', initialOffset, ' divided by ', EVENTS_PER_BATCH)
+        console.error('could not cache redis offset as: ', newOffset, ' calculated using ', initialOffset, ' divided by ', EVENTS_PER_BATCH)
         throw e
     }
     


### PR DESCRIPTION
A user reported getting the error: "ERR value is not an integer or out of range" in [this community slack thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1652427366471769) when using this plugin

The internet suggests that is a redis error when sending a float to a method expecting an integer

A likely candidate for this is a method where we divide two numbers together when caching a value to the redis offset key

This calls Math.floor on the divided value to coerce it to an integer